### PR TITLE
Cleanup

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,0 +1,7 @@
+[data]
+{{- if eq .chezmoi.os "darwin" }}
+	defaultShell = "zsh"
+{{ else }}
+	defaultShell = "bash"
+{{ end -}}
+

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,0 +1,2 @@
+install.sh
+*.md

--- a/Brewfile.tmpl
+++ b/Brewfile.tmpl
@@ -1,0 +1,2 @@
+brew "lazygit"
+brew "zellij"

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -1,3 +1,0 @@
-{{ template "shell_common" . }}
-
-eval "$(starship init zsh)"

--- a/empty_dot_swrc.tmpl
+++ b/empty_dot_swrc.tmpl
@@ -1,3 +1,5 @@
+printf "Loading sw custom shell setup"
+
 load_if_exists() {
 	if [[ -f $1 ]]; then
 		. $1

--- a/empty_dot_swrc.tmpl
+++ b/empty_dot_swrc.tmpl
@@ -1,0 +1,10 @@
+load_if_exists() {
+	if [[ -f $1 ]]; then
+		. $1
+	fi
+}
+
+load_if_exists "$HOME/.aliases"
+load_if_exists "$HOME/.tokens"
+
+eval "$(starship init {{ .defaultShell -}})"

--- a/run_once_install-homebrew.sh.tmpl
+++ b/run_once_install-homebrew.sh.tmpl
@@ -1,0 +1,5 @@
+{{- if eq .chezmoi.os "darwin" -}}
+#!/bin/sh
+
+brew --version || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+{{ end -}}

--- a/run_once_install-ohmyzsh.sh.tmpl
+++ b/run_once_install-ohmyzsh.sh.tmpl
@@ -1,6 +1,0 @@
-{{- if (eq .chezmoi.os "darwin") -}}
-#! /bin/sh
-if [ -z $ZSH ]; then
-	curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh | sh
-fi
-{{ end }}

--- a/run_once_source-custom-sh.sh.tmpl
+++ b/run_once_source-custom-sh.sh.tmpl
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+{{- if eq .defaultShell "zsh" }}
+rcfile="$HOME/.zshrc"
+{{ else if eq .defaultShell "bash" }}
+rcfile="$HOME/.bashrc"
+{{ end -}}
+
+if [[ ! -f "$rcfile" ]]; then
+	touch "$rcfile"
+fi
+
+grep '. $HOME/.swrc' "$rcfile" || printf "\n. \"$HOME/.swrc\"\n" >> "$rcfile" 
+
+

--- a/run_onchange_brew-pkgs.sh.tmpl
+++ b/run_onchange_brew-pkgs.sh.tmpl
@@ -1,0 +1,7 @@
+{{- if eq .chezmoi.os "darwin" -}}
+#!/bin/sh
+
+# Include brewfile hash to re-run this script whenever the brewfile changes
+# brewfile hash: {{ include "Brewfile.tmpl" | sha256sum }}
+brew bundle --file "$HOME/Brewfile"
+{{end}}


### PR DESCRIPTION
Remove some unused files and reorganize code

- Avoid a common `~/.zshrc` since other tools commonly write to the .zshrc. Instead, add a common file and a one-time script that sources this file in `~/.zshrc`. This make `.localrc` unnecessary
- Remove oh-my-zsh since I'm using starship everywhere now. 